### PR TITLE
candycane-repository-browser v0.1.3

### DIFF
--- a/entries2.json
+++ b/entries2.json
@@ -57,10 +57,10 @@
   "id":"cc_repository_browser",
   "name":"Repository Browser Plugin",
   "description":"simple github? repository browser.",
-  "url":"https:\/\/github.com\/hamaco\/candycane-repository-browser\/archive\/v0.1.2.zip",
+  "url":"https:\/\/github.com\/hamaco\/candycane-repository-browser\/archive\/v0.1.3.zip",
   "author":"hamaco",
   "author_url":"https:\/\/github.com\/hamaco",
-  "version":"0.1.2"
+  "version":"0.1.3"
 },
 "cc_u-nya-":{
   "id":"cc_u-nya-",


### PR DESCRIPTION
GitHubのAPIから正常にデータ取得できないという致命的なバグがあったので直しましたorz
