### PR TITLE
add candycane overall activity menu plugin.

### DIFF
--- a/entries2.json
+++ b/entries2.json
@@ -115,5 +115,14 @@
   "author":"hamaco",
   "author_url":"https:\/\/github.com\/hamaco",
   "version":"0.1.0"
+},
+"cc_overall_activity_menu":{
+  "id":"cc_overall_activity_menu",
+  "name":"CandyCane Overall Activity Menu Plugin",
+  "description":"add menu to overall activity page.",
+  "url":"https:\/\/github.com\/hamaco\/candycane-overall-activity-menu\/archive\/0.0.1.zip",
+  "author":"hamaco",
+  "author_url":"https:\/\/github.com\/hamaco",
+  "version":"0.0.1"
 }
 }

--- a/entries2.json
+++ b/entries2.json
@@ -124,5 +124,14 @@
   "author":"hamaco",
   "author_url":"https:\/\/github.com\/hamaco",
   "version":"0.0.1"
+},
+"cc_default_due_date":{
+  "id":"cc_default_due_date",
+  "name":"CandyCane DDD(Default Due Date) Plugin",
+  "description":"this is candycane plugin set 7 days after to due date.",
+  "url":"https:\/\/github.com\/hamaco\/candycane-default-due-date\/archive\/0.1.0.zip",
+  "author":"hamaco",
+  "author_url":"https:\/\/github.com\/hamaco",
+  "version":"0.1.0"
 }
 }

--- a/entries2.json
+++ b/entries2.json
@@ -133,5 +133,14 @@
   "author":"hamaco",
   "author_url":"https:\/\/github.com\/hamaco",
   "version":"0.1.0"
+},
+"cc_youtube_video":{
+  "id":"cc_youtube_video",
+  "name":"CandyCane YouTube Embed Tag Plugin",
+  "description":"youtube embed tag macro.",
+  "url":"https:\/\/github.com\/hamaco\/candycane-youtube-video\/archive\/1.0.0.zip",
+  "author":"hamaco",
+  "author_url":"https:\/\/github.com\/hamaco",
+  "version":"1.0.0"
 }
 }


### PR DESCRIPTION
[Redmine のメニューに「すべての活動」へのリンクを追加するプラグインを作った - すえひろがりっっっっ!](http://d.hatena.ne.jp/suer/20140203/redmine_overall_activity_menu) のCandyCane版作りました。
